### PR TITLE
docs: align Gateway EVM references with useConnection pattern

### DIFF
--- a/plugins/circle/skills/use-gateway/references/evm-to-evm.md
+++ b/plugins/circle/skills/use-gateway/references/evm-to-evm.md
@@ -10,7 +10,7 @@ Browser-wallet EVM -> EVM transfer flow:
 import { useState } from "react";
 import { maxUint64, parseUnits, pad, type Hex, zeroAddress } from "viem";
 import {
-  useAccount,
+  useConnection,
   useChainId,
   useSignTypedData,
   useSwitchChain,
@@ -100,7 +100,7 @@ function evmAddressToBytes32(address: Hex): Hex {
  * 4) Call gatewayMint on destination chain
  */
 export default function TransferGatewayBalanceEvmEvm() {
-  const { address: evmAddress } = useAccount();
+  const { address: evmAddress } = useConnection();
   const chainId = useChainId();
   const { mutateAsync: signTypedData } = useSignTypedData();
   const { switchChainAsync } = useSwitchChain();

--- a/plugins/circle/skills/use-gateway/references/solana-to-evm.md
+++ b/plugins/circle/skills/use-gateway/references/solana-to-evm.md
@@ -213,10 +213,10 @@ async function signSolanaBurnIntentWithWallet(
       .map((b) => b.toString(16).padStart(2, "0"))
       .join("")}`) as Hex;
   } catch (error) {
-    console.warn(`
-      This wallet does not support signing transactions that aren't strictly Solana t
-      ransactions. Try another wallet such as Solflare.`
-      , error);
+    console.warn(
+      "This wallet does not support signing transactions that aren't strictly Solana transactions. Try another wallet such as Solflare.",
+      error,
+    );
     throw error;
   }
 }


### PR DESCRIPTION
Aligns the Gateway EVM reference examples with the wagmi v3 canonical API.

## Changes

**evm-to-evm.md** — replaces the deprecated `useAccount` alias with `useConnection`, matching the pattern already used in the other three Gateway EVM references (`deposit-evm.md`, `solana-to-evm.md`, `evm-to-solana.md`).

In wagmi v3, `useAccount` was [renamed to `useConnection`](https://wagmi.sh/react/guides/migrate-from-v2-to-v3). The old name still works as a deprecated re-export, but the rest of the Gateway skill already uses the new name.

**solana-to-evm.md** — fixes a broken line wrap inside `console.warn` that splits the word "transactions" across two lines (`"Solana t\nransactions"`).