### PR TITLE
docs: add decimal footgun section to use-arc skill

### DIFF
--- a/plugins/circle/skills/use-arc/SKILL.md
+++ b/plugins/circle/skills/use-arc/SKILL.md
@@ -113,6 +113,48 @@ Use CCTP to bridge USDC from other chains. Arc's CCTP domain is `26`. See the `b
 - ALWAYS use 18 decimals for native gas amounts and 6 decimals for ERC-20 USDC amounts.
 - NEVER target mainnet -- Arc is testnet only.
 
+## Common Pitfalls
+
+### The Decimal Footgun
+
+Because Arc uses USDC as its native gas token, it is tempting to assume **every** amount on Arc uses 18 decimals -- the convention most EVM chains follow for their native token. That assumption is wrong. On Arc:
+
+- **Native gas** (the value in `msg.value`) uses **18 decimals**, exactly like ETH elsewhere.
+- **ERC-20 USDC** (the token at `0x3600...0000`) uses **6 decimals**.
+
+Mixing these up is one of the most common and expensive mistakes when building on Arc.
+
+**Concrete failure scenario.** You want to transfer **10 USDC**:
+
+- ❌ Using `parseEther('10')` sends `10_000_000_000_000_000_000` (10^18) base units.
+- ✅ Using `parseUnits('10', 6)` sends `10_000_000` (10^6) base units.
+
+That is a **1,000,000,000,000x (one trillion times)** error -- you would be trying to move ten trillion USDC instead of ten.
+
+```typescript
+import { parseEther, parseUnits } from 'viem'
+
+// ❌ WRONG -- treats USDC as an 18-decimal token
+await walletClient.writeContract({
+  address: USDC_ADDRESS,
+  abi: erc20Abi,
+  functionName: 'transfer',
+  args: [recipient, parseEther('10')], // 10_000_000_000_000_000_000 (10^18)
+})
+
+// ✅ CORRECT -- USDC is a 6-decimal ERC-20
+await walletClient.writeContract({
+  address: USDC_ADDRESS,
+  abi: erc20Abi,
+  functionName: 'transfer',
+  args: [recipient, parseUnits('10', 6)], // 10_000_000 (10^6)
+})
+```
+
+**Rule to remember:** If it's ERC-20 USDC, always use `parseUnits(amount, 6)`. If it's native gas (`msg.value`), it's 18 decimals like ETH.
+
+**Why it matters.** This error rarely fails loudly. In the best case the transaction reverts for insufficient balance and you catch it immediately. In the worst case it **silently succeeds with a wildly wrong amount** -- if the receiving contract doesn't validate bounds, you can drain a wallet or break a payment flow before anyone notices.
+
 ## Next Steps
 
 Arc is natively supported across Circle's product suite. Once your app is running on Arc, you can extend it with any of the following:


### PR DESCRIPTION
## Summary

Small, focused addition to the existing `use-arc` skill: a new **Common Pitfalls → The Decimal Footgun** section that reinforces the existing decimal guidance with a concrete, real-world example.

## Motivation

Arc uses USDC as its native gas token, which makes it easy to assume *every* amount uses 18 decimals like a typical EVM chain — when in fact ERC-20 USDC uses 6 decimals and only native gas (`msg.value`) uses 18. This is a real trap: we hit exactly this decimal mismatch in one of our own projects (a USDC payment flow), where `parseEther` was used instead of `parseUnits(amount, 6)`, producing an amount 10^12 times too large. We wrote it up in a Paragraph article (https://paragraph.com/@coliseum/the-18-vs-6-decimal-footgun-on-arc-what-nearly-killed-coliseum) as a lesson learned, and this PR distills that experience into the skill so other builders (and agents) avoid the same mistake.

## What's added

- A concrete failure scenario with real numbers (`parseEther('10')` → 10^18 vs `parseUnits('10', 6)` → 10^6, a 1,000,000,000,000x error)
- A ❌ WRONG / ✅ CORRECT TypeScript/viem code comparison
- A one-line rule to remember
- A note on why it's dangerous: can revert on insufficient balance, or worse, silently succeed with a wildly wrong amount

## Consistency

This complements — and does not duplicate — the existing **"Dual decimals"** Core Concept and the **Best Practices** decimal rule. It follows the same markdown style, code-block conventions, and tone as the rest of the file.