### PR TITLE
docs(skills): migrate Arc documentation URLs to canonical docs.arc.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ No. Skills work standalone. MCP adds accuracy for SDK details that change betwee
 
 ## Resources
 - [Circle Developer Docs](https://developers.circle.com)
-- [Arc Docs](https://docs.arc.network)
+- [Arc Docs](https://docs.arc.io)
 - [Circle MCP Server](https://developers.circle.com/ai/mcp)
 - [Testnet Faucet](https://faucet.circle.com)
 - [USDC Contract Addresses](https://developers.circle.com/stablecoins/usdc-contract-addresses)

--- a/plugins/circle/skills/bridge-stablecoin/SKILL.md
+++ b/plugins/circle/skills/bridge-stablecoin/SKILL.md
@@ -198,8 +198,8 @@ Both App Kit and Bridge Kit have two error categories:
 
 ## Reference Links
 
-- [Circle App Kit SDK](https://docs.arc.network/app-kit)
-- [Circle Bridge Kit SDK](https://docs.arc.network/app-kit/bridge)
+- [Circle App Kit SDK](https://docs.arc.io/app-kit)
+- [Circle Bridge Kit SDK](https://docs.arc.io/app-kit/bridge)
 - [CCTP Documentation](https://developers.circle.com/cctp)
 - [Circle Developer Docs](https://developers.circle.com/llms.txt) -- **Always read this first** when looking for relevant documentation from the source website.
 

--- a/plugins/circle/skills/swap-tokens/SKILL.md
+++ b/plugins/circle/skills/swap-tokens/SKILL.md
@@ -172,7 +172,7 @@ const SUPPORTED_TOKENS = [
 ] as const;
 ```
 
-Any token can also be specified by contract address. The aliases above are shortcuts for the most common tokens. See [Supported Blockchains](https://docs.arc.network/app-kit/references/supported-blockchains) for the latest list.
+Any token can also be specified by contract address. The aliases above are shortcuts for the most common tokens. See [Supported Blockchains](https://docs.arc.io/app-kit/references/supported-blockchains) for the latest list.
 
 ### Additional Swap Configuration
 
@@ -310,8 +310,8 @@ try {
 - ALWAYS use exported SDK types instead of creating custom interfaces.
 
 ## Reference Links
-- [Circle App Kit SDK](https://docs.arc.network/app-kit)
-- [Circle Swap Kit SDK](https://docs.arc.network/app-kit/swap)
+- [Circle App Kit SDK](https://docs.arc.io/app-kit)
+- [Circle Swap Kit SDK](https://docs.arc.io/app-kit/swap)
 - [Circle Developer Docs](https://developers.circle.com/llms.txt) -- **Always read this first** when looking for relevant documentation from the source website.
 
 ## Alternatives

--- a/plugins/circle/skills/swap-tokens/references/crosschain-token-movement.md
+++ b/plugins/circle/skills/swap-tokens/references/crosschain-token-movement.md
@@ -62,7 +62,7 @@ const crosschainMovement = async (): Promise<void> => {
   // Step 2: Bridge USDC from Ethereum to Base
   // useForwarder: true lets Circle's Forwarding Service handle attestation
   // fetching and mint submission on the destination chain automatically.
-  // See: https://docs.arc.network/app-kit/tutorials/bridge/use-forwarding-service
+  // See: https://docs.arc.io/app-kit/tutorials/bridge/use-forwarding-service
   try {
     const bridgeResult = await kit.bridge({
       from: { adapter, chain: "Ethereum" },
@@ -108,7 +108,7 @@ const crosschainMovement = async (): Promise<void> => {
   // Step 1: Bridge USDC from Ethereum to Base
   // useForwarder: true lets Circle's Forwarding Service handle attestation
   // fetching and mint submission on the destination chain automatically.
-  // See: https://docs.arc.network/app-kit/tutorials/bridge/use-forwarding-service
+  // See: https://docs.arc.io/app-kit/tutorials/bridge/use-forwarding-service
   let bridgeResult;
   try {
     bridgeResult = await kit.bridge({
@@ -194,7 +194,7 @@ const crosschainMovement = async (): Promise<void> => {
   // Step 2: Bridge USDC from Ethereum to Base
   // useForwarder: true lets Circle's Forwarding Service handle attestation
   // fetching and mint submission on the destination chain automatically.
-  // See: https://docs.arc.network/app-kit/tutorials/bridge/use-forwarding-service
+  // See: https://docs.arc.io/app-kit/tutorials/bridge/use-forwarding-service
   let bridgeResult;
   try {
     bridgeResult = await kit.bridge({

--- a/plugins/circle/skills/unify-balance/SKILL.md
+++ b/plugins/circle/skills/unify-balance/SKILL.md
@@ -269,8 +269,8 @@ try {
 
 ## Reference Links
 
-- [Circle App Kit SDK](https://docs.arc.network/app-kit)
-- [Unified Balance Kit SDK](https://docs.arc.network/app-kit/unified-balance)
+- [Circle App Kit SDK](https://docs.arc.io/app-kit)
+- [Unified Balance Kit SDK](https://docs.arc.io/app-kit/unified-balance)
 - [Circle Gateway](https://developers.circle.com/gateway)
 - [Circle Developer Docs](https://developers.circle.com/llms.txt) -- **Always read this first** when looking for relevant documentation from the source website.
 

--- a/plugins/circle/skills/use-arc/SKILL.md
+++ b/plugins/circle/skills/use-arc/SKILL.md
@@ -135,7 +135,7 @@ Arc is natively supported across Circle's product suite. Once your app is runnin
 
 ## Reference Links
 
-- [Arc Docs](https://docs.arc.network/llms.txt) -- **Always read this first** when looking for relevant documentation from the source website.
+- [Arc Docs](https://docs.arc.io/llms.txt) -- **Always read this first** when looking for relevant documentation from the source website.
 - [Arc Explorer](https://testnet.arcscan.app)
 - [Circle Faucet](https://faucet.circle.com)
 - [Circle Developer Docs](https://developers.circle.com/llms.txt) -- **Always read this first** when looking for relevant documentation from the source website.

--- a/plugins/circle/skills/use-gateway/SKILL.md
+++ b/plugins/circle/skills/use-gateway/SKILL.md
@@ -32,7 +32,7 @@ Canonical source docs for verification:
 - Gateway quickstarts:
   - `https://developers.circle.com/gateway/quickstarts/unified-balance-evm.md`
   - `https://developers.circle.com/gateway/quickstarts/unified-balance-solana.md`
-- Arc tutorial: `https://docs.arc.network/arc/tutorials/access-usdc-crosschain.md`
+- Arc tutorial: `https://docs.arc.io/arc/tutorials/access-usdc-crosschain`
 
 ## Quick Reference
 

--- a/plugins/circle/skills/use-gateway/references/deposit-evm-browser-wallet.md
+++ b/plugins/circle/skills/use-gateway/references/deposit-evm-browser-wallet.md
@@ -5,7 +5,7 @@ This example uses Arc Testnet, but the same deposit pattern applies to any suppo
 Canonical runnable references:
 - Create unified USDC balance: https://developers.circle.com/gateway/howtos/create-unified-usdc-balance.md
 - Unified balance EVM quickstart: https://developers.circle.com/gateway/quickstarts/unified-balance-evm.md
-- Arc crosschain USDC tutorial: https://docs.arc.network/arc/tutorials/access-usdc-crosschain.md
+- Arc crosschain USDC tutorial: https://docs.arc.io/arc/tutorials/access-usdc-crosschain
 
 ## What this does
 

--- a/plugins/circle/skills/use-gateway/references/deposit-evm.md
+++ b/plugins/circle/skills/use-gateway/references/deposit-evm.md
@@ -5,7 +5,7 @@ This example uses Arc Testnet, but the same deposit pattern applies to any suppo
 Canonical runnable references:
 - Create unified USDC balance: https://developers.circle.com/gateway/howtos/create-unified-usdc-balance.md
 - Unified balance EVM quickstart: https://developers.circle.com/gateway/quickstarts/unified-balance-evm.md
-- Arc crosschain USDC tutorial: https://docs.arc.network/arc/tutorials/access-usdc-crosschain.md
+- Arc crosschain USDC tutorial: https://docs.arc.io/arc/tutorials/access-usdc-crosschain
 
 ## What this does
 

--- a/plugins/circle/skills/use-gateway/references/evm-to-evm.md
+++ b/plugins/circle/skills/use-gateway/references/evm-to-evm.md
@@ -5,7 +5,7 @@ This example burns from Arc Testnet and Avalanche Fuji, then mints on Sei Testne
 Canonical runnable references:
 - Transfer unified USDC balance: https://developers.circle.com/gateway/howtos/transfer-unified-usdc-balance.md
 - Unified balance EVM quickstart: https://developers.circle.com/gateway/quickstarts/unified-balance-evm.md
-- Arc crosschain USDC tutorial: https://docs.arc.network/arc/tutorials/access-usdc-crosschain.md
+- Arc crosschain USDC tutorial: https://docs.arc.io/arc/tutorials/access-usdc-crosschain
 
 ## What this does
 

--- a/plugins/circle/skills/use-gateway/references/evm-to-solana.md
+++ b/plugins/circle/skills/use-gateway/references/evm-to-solana.md
@@ -5,7 +5,7 @@ This example burns from Arc Testnet and mints on Solana Devnet. The same pattern
 Canonical runnable references:
 - Transfer unified USDC balance: https://developers.circle.com/gateway/howtos/transfer-unified-usdc-balance.md
 - Unified balance Solana quickstart: https://developers.circle.com/gateway/quickstarts/unified-balance-solana.md
-- Arc crosschain USDC tutorial: https://docs.arc.network/arc/tutorials/access-usdc-crosschain.md
+- Arc crosschain USDC tutorial: https://docs.arc.io/arc/tutorials/access-usdc-crosschain
 
 ## What this does
 

--- a/plugins/circle/skills/use-gateway/references/solana-to-evm.md
+++ b/plugins/circle/skills/use-gateway/references/solana-to-evm.md
@@ -6,7 +6,7 @@ Canonical runnable references:
 - Transfer unified USDC balance: https://developers.circle.com/gateway/howtos/transfer-unified-usdc-balance.md
 - Unified balance EVM quickstart: https://developers.circle.com/gateway/quickstarts/unified-balance-evm.md
 - Unified balance Solana quickstart: https://developers.circle.com/gateway/quickstarts/unified-balance-solana.md
-- Arc crosschain USDC tutorial: https://docs.arc.network/arc/tutorials/access-usdc-crosschain.md
+- Arc crosschain USDC tutorial: https://docs.arc.io/arc/tutorials/access-usdc-crosschain
 
 ## What this does
 


### PR DESCRIPTION
## Summary

Updates all Arc documentation references across `circlefin/skills` and reference documentation from the legacy `docs.arc.network` domain (which returns 301 HTTP redirects) to the canonical `docs.arc.io` domain, and updates tutorial links to their active paths.

### Changes
- Updated `README.md` link to `https://docs.arc.io`.
- Updated `use-arc/SKILL.md` LLM index to `https://docs.arc.io/llms.txt`.
- Updated `swap-tokens/SKILL.md` and `swap-tokens/references/crosschain-token-movement.md` App Kit & Swap Kit links to `docs.arc.io`.
- Updated `bridge-stablecoin/SKILL.md` App Kit & Bridge Kit links to `docs.arc.io`.
- Updated `unify-balance/SKILL.md` App Kit & Unified Balance Kit links to `docs.arc.io`.
- Updated `use-gateway/SKILL.md` and all its sub-references (`deposit-evm.md`, `deposit-evm-browser-wallet.md`, `evm-to-evm.md`, `evm-to-solana.md`, `solana-to-evm.md`) to `https://docs.arc.io/arc/tutorials/access-usdc-crosschain`.

### Verification
- Verified all updated `docs.arc.io` URLs return `HTTP 200 OK` via curl.
