### PR TITLE
docs(use-arc): fix dangling chain-definition reference in wagmi example

### DIFF
--- a/plugins/circle/skills/use-arc/SKILL.md
+++ b/plugins/circle/skills/use-arc/SKILL.md
@@ -58,7 +58,7 @@ PRIVATE_KEY=         # Deployer wallet private key
 
 ### 1. Frontend App (React + wagmi)
 
-Use the `arcTestnet` chain definition from Prerequisites / Setup. Pass it to your wagmi config:
+Import the `arcTestnet` chain from `viem/chains` — it ships with viem, so no custom `defineChain` is required. Pass it to your wagmi config:
 
 ```typescript
 import { createConfig, http } from 'wagmi'


### PR DESCRIPTION
**What**

The "Frontend App (React + wagmi)" section says to use "the `arcTestnet` chain definition from Prerequisites / Setup", but the Prerequisites / Setup section only defines environment variables — there is no chain definition there, so the instruction points at content that does not exist.

**Fix**

Reword the sentence to match what the skill already recommends elsewhere: `arcTestnet` ships with `viem/chains` (see the Best Practices note: *"a custom chain definition is NEVER required"*), and the code sample immediately below already imports it from `viem/chains`. Confirmed `arcTestnet` is exported from viem: https://github.com/wevm/viem/blob/main/src/chains/index.ts

Docs-only, one line. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
